### PR TITLE
Clean-up of loader.py

### DIFF
--- a/edam_mcp/config.py
+++ b/edam_mcp/config.py
@@ -9,8 +9,8 @@ class Settings(BaseSettings):
 
     # EDAM Ontology Configuration
     edam_ontology_url: str = Field(
-        default="https://raw.githubusercontent.com/edamontology/edamontology/master/EDAM_dev.owl",
-        description="URL to the EDAM ontology OWL file",
+        default="https://edamontology.org/EDAM_stable.owl",
+        description="URL to the latest stable EDAM ontology OWL file",
     )
 
     # Matching Configuration

--- a/edam_mcp/ontology/loader.py
+++ b/edam_mcp/ontology/loader.py
@@ -178,7 +178,7 @@ class OntologyLoader:
 
         return matches[:max_results]
 
-    def get_concept_hierarchy(self, concept_uri: str) -> list[str]:  # currently  not used
+    def get_concept_hierarchy(self, concept_uri: str) -> list[str]:  # TODO: currently  not used
         """Get the full hierarchy path for a concept."""
         hierarchy = []
         current_uri = concept_uri

--- a/edam_mcp/ontology/loader.py
+++ b/edam_mcp/ontology/loader.py
@@ -2,9 +2,8 @@
 
 import logging
 
-import requests
 from rdflib import RDF, Graph, Namespace, URIRef
-from rdflib.namespace import RDFS, SKOS
+from rdflib.namespace import OWL, RDFS, SKOS
 
 from ..config import settings
 
@@ -12,7 +11,6 @@ logger = logging.getLogger(__name__)
 
 # EDAM namespaces
 EDAM = Namespace("http://edamontology.org/")
-OWL = Namespace("http://www.w3.org/2002/07/owl#")
 
 
 class OntologyLoader:
@@ -38,13 +36,13 @@ class OntologyLoader:
         try:
             logger.info(f"Loading EDAM ontology from {self.ontology_url}")
 
-            # Download ontology file
-            response = requests.get(self.ontology_url, timeout=30)
-            response.raise_for_status()
-
             # Parse RDF/OWL content
             self.graph = Graph()
-            self.graph.parse(data=response.content, format="xml")
+            self.graph.bind("edam", EDAM)
+            self.graph.bind("owl", OWL)
+            self.graph.bind("skos", SKOS)
+
+            self.graph.parse(self.ontology_url)
 
             # Extract concepts
             self._extract_concepts()
@@ -59,6 +57,7 @@ class OntologyLoader:
     def _extract_concepts(self) -> None:
         """Extract concept information from the loaded graph."""
         if not self.graph:
+            logger.error("No EDAM OWL file loaded.")
             return
 
         for concept_uri in self.graph.subjects(RDF.type, OWL.Class):
@@ -80,26 +79,16 @@ class OntologyLoader:
             Dictionary containing concept data or None if invalid.
         """
         try:
-            # Get label
             label = self._get_literal_value(concept_uri, RDFS.label)
             if not label:
                 return None
 
-            # Get definition
-            definition = self._get_literal_value(concept_uri, SKOS.definition)
-
-            # Get synonyms
-            synonyms = self._get_literal_values(concept_uri, SKOS.altLabel)
-
-            # Determine concept type from URI
-            concept_type = self._determine_concept_type(str(concept_uri))
-
             return {
                 "uri": str(concept_uri),
                 "label": label,
-                "definition": definition,
-                "synonyms": synonyms,
-                "type": concept_type,
+                "definition": self._get_literal_value(concept_uri, SKOS.definition),
+                "synonyms": self._get_literal_values(concept_uri, SKOS.altLabel),
+                "type": self._determine_concept_type(str(concept_uri)),
                 "parents": self._get_parent_concepts(concept_uri),
                 "children": self._get_child_concepts(concept_uri),
             }
@@ -189,7 +178,7 @@ class OntologyLoader:
 
         return matches[:max_results]
 
-    def get_concept_hierarchy(self, concept_uri: str) -> list[str]:
+    def get_concept_hierarchy(self, concept_uri: str) -> list[str]:  # currently  not used
         """Get the full hierarchy path for a concept."""
         hierarchy = []
         current_uri = concept_uri

--- a/edam_mcp/ontology/matcher.py
+++ b/edam_mcp/ontology/matcher.py
@@ -54,7 +54,7 @@ class ConceptMatcher:
             processed_text = preprocess_text(text)
 
             # Generate embedding
-            embedding = self.embedding_model.encode(processed_text)
+            embedding = self.embedding_model.encode(processed_text, show_progress_bar=False)
             self.concept_embeddings[uri] = embedding
 
         logger.info(f"Built embeddings for {len(self.concept_embeddings)} concepts")
@@ -89,7 +89,7 @@ class ConceptMatcher:
             processed_description += " " + preprocess_text(context)
 
         # Generate embedding for the description
-        description_embedding = self.embedding_model.encode(processed_description)
+        description_embedding = self.embedding_model.encode(processed_description, show_progress_bar=False)
 
         # Calculate similarities
         similarities = self._calculate_similarities(description_embedding)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
     "pydantic-settings>=2.0.0",
     "requests>=2.31.0",
     "rdflib>=6.0.0",
-    "owlready2>=0.45.0",
     "scikit-learn>=1.3.0",
     "sentence-transformers>=2.2.0",
     "numpy>=1.24.0",

--- a/uv.lock
+++ b/uv.lock
@@ -268,15 +268,7 @@ requires-dist = [
     { name = "fastmcp", specifier = ">=2.10.6" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "numpy", specifier = ">=1.24.0" },
-<<<<<<< Updated upstream
-    { name = "owlready2", specifier = ">=0.45.0" },
-<<<<<<< Updated upstream
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7.0" },
-=======
-=======
-    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7.0" },
->>>>>>> Stashed changes
->>>>>>> Stashed changes
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -246,7 +246,6 @@ source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
     { name = "numpy" },
-    { name = "owlready2" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "rdflib" },
@@ -269,8 +268,15 @@ requires-dist = [
     { name = "fastmcp", specifier = ">=2.10.6" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "numpy", specifier = ">=1.24.0" },
+<<<<<<< Updated upstream
     { name = "owlready2", specifier = ">=0.45.0" },
+<<<<<<< Updated upstream
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7.0" },
+=======
+=======
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7.0" },
+>>>>>>> Stashed changes
+>>>>>>> Stashed changes
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
@@ -830,12 +836,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb9
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
 ]
-
-[[package]]
-name = "owlready2"
-version = "0.48"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8d/79/01daa72fbd07b1d4dd0907356d0ae486a684f0bd4654430f27a3e31206ee/owlready2-0.48.tar.gz", hash = "sha256:86b4d8500d769a674c524b54397fdd738ff5d0a96878432b69f4d606d6a7a4d8", size = 27298462, upload-time = "2025-05-27T09:15:03.095Z" }
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
> [!WARNING]
> This is a follow up from https://github.com/edamontology/edammcp/pull/10, merge that one first to make the review of this easier

Clean-up of the `loader.py` code

- Delete library `Owlready2` since it is not used. `rdflib` seems to be more maintained (last release Mar 2025)
- Use the latest stable owl file
- `Rdflib` can read directly from the internet, we don't need to use `requests`