### PR TITLE
Fixed default URL in config.py

### DIFF
--- a/edam_mcp/config.py
+++ b/edam_mcp/config.py
@@ -12,8 +12,8 @@ class Settings(BaseSettings):
     
     # EDAM Ontology Configuration
     edam_ontology_url: str = Field(
-        default="https://raw.githubusercontent.com/edamontology/edamontology/main/EDAM_dev.owl",
-        description="URL to the EDAM ontology OWL file"
+        default="https://edamontology.org/EDAM.owl",
+        description="URL to the default version of the EDAM ontology OWL file"
     )
     
     # Matching Configuration

--- a/edam_mcp/config.py
+++ b/edam_mcp/config.py
@@ -10,7 +10,7 @@ class Settings(BaseSettings):
     # EDAM Ontology Configuration
     edam_ontology_url: str = Field(
         default="https://edamontology.org/EDAM.owl",
-        description="URL to the default version of the EDAM ontology OWL file"
+        description="URL to the default version of the EDAM ontology OWL file",
     )
 
     # Matching Configuration

--- a/edam_mcp/config.py
+++ b/edam_mcp/config.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
     
     # EDAM Ontology Configuration
     edam_ontology_url: str = Field(
-        default="https://raw.githubusercontent.com/edamontology/edamontology/master/EDAM_dev.owl",
+        default="https://raw.githubusercontent.com/edamontology/edamontology/main/EDAM_dev.owl",
         description="URL to the EDAM ontology OWL file"
     )
     


### PR DESCRIPTION
There was a wrong name of the default branch in the githubusercontent URL.

We could also consider using the latest released https://edamontology.org/EDAM.owl, which usually is slightly more stable.