### PR TITLE
Fix to remove warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ uv run python examples/simple_test.py
 uv run python examples/basic_usage.py
 
 # Start the MCP server
-uv run python -m edam_mcp.main
+uv run edam-mcp
 ```
 
 ### Example Output


### PR DESCRIPTION
This edit replaces the README
 `uv run python -m edam_mcp.main`
with
`uv run edam-mcp`

to remove the warning:
       
`<frozen runpy>:128: RuntimeWarning: 'edam_mcp.main' found in sys.modules after import of package 'edam_mcp', but prior to execution of 'edam_mcp.main'; this may result in unpredictable behaviour`

